### PR TITLE
Slow-mo added

### DIFF
--- a/Assets/Scenes/Prototype Scenes/SimpleTilemap.unity
+++ b/Assets/Scenes/Prototype Scenes/SimpleTilemap.unity
@@ -211,6 +211,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 661092821}
     - target: {fileID: -6027955848104475147, guid: 33ab23f5c1400c74bae73e2161dc02d2, type: 3}
+      propertyPath: stamina
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -6027955848104475147, guid: 33ab23f5c1400c74bae73e2161dc02d2, type: 3}
       propertyPath: maxSpeed
       value: 24.5
       objectReference: {fileID: 0}
@@ -4195,7 +4199,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d6a2e4addfe1c574885e1fc35da481c2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  waterTileCollider: {fileID: 1504338641}
+  waterDampeningValue: 0
 --- !u!1 &1636274749
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -15,8 +15,10 @@ public class PlayerController : MonoBehaviour
     [SerializeField] float minSpeed;
     [SerializeField] public float bounceForce;
     [SerializeField] public float rotateForce;
+    [SerializeField] int stamina;
     public bool lose = false;
     public bool launched = false;
+    public bool slowMotion = false;
     Vector2 reflectedVector;
     RaycastHit2D ray;
     Vector2 direction;
@@ -24,7 +26,7 @@ public class PlayerController : MonoBehaviour
     Vector3 originalPos;
     float angle;
 
-    private int stamina;
+    
 
     private int maxStamina;
 
@@ -72,22 +74,28 @@ public class PlayerController : MonoBehaviour
         }
 
         // initial launch with left click + drag, otherwise must activate stamina using right click
-        if (!launched)
+        if (!launched || stamina > 0)
         {
             if (Input.GetMouseButtonDown(0))
             {
                 originalPos = Input.mousePosition;
-                //store initial mouse location
+                if (launched)
+                {
+                    slowMotion = true;
+                    playerRb.linearVelocity = playerRb.linearVelocity / 2;
+                }
             }
-            // if (Input.GetMouseButton(0))
-            // {
-
-            // }
             if (Input.GetMouseButtonUp(0))
             {
+                if (slowMotion)
+                {
+                    playerRb.linearVelocity = playerRb.linearVelocity * 2;
+                }
                 float xChange = -(Input.mousePosition.x - originalPos.x) / 10;
                 float yChange = -(Input.mousePosition.y - originalPos.y) / 10;
                 playerRb.linearVelocity = new Vector2(xChange, yChange);
+                slowMotion = false;
+                DecrementStamina();
                 if (playerRb.linearVelocity.magnitude > 0.2 * maxLaunchSpeed)
                 {
                     launched = true;
@@ -102,6 +110,7 @@ public class PlayerController : MonoBehaviour
                     // indicate to player that launch force was too low!
                     playerRb.linearVelocity = new Vector2(0, 0);
                 }
+                
             }
         }
         if (playerRb.linearVelocityX < 0)


### PR DESCRIPTION
-Added slow-motion
-To activate slow-motion, click and drag the same way you do at launch, which will cause a slow-mo effect, slowing down the player by half
-Using extra launches uses up stamina
-Made stamina serialized for easy change

-NOTE: the hazards around the map like water still effect the player the same way. Eventually will need to half the effect of these hazards if the player is in slowmo
-ANOTHER NOTE: we might want to change the speedometer to either scale with the slowdown or to disappear when player is in slow mo to avoid speed confusion